### PR TITLE
Allow LogRecord.app nullable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 /test.db
 /dist
 /log4django.egg-info
+
+.idea
+*.pyc
+*~

--- a/log4django/migrations/0003_auto__chg_field_logrecord_app.py
+++ b/log4django/migrations/0003_auto__chg_field_logrecord_app.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'LogRecord.app'
+        db.alter_column(u'log4django_logrecord', 'app_id', self.gf('django.db.models.fields.related.ForeignKey')(null=True, to=orm['log4django.App']))
+
+    def backwards(self, orm):
+
+        # User chose to not deal with backwards NULL issues for 'LogRecord.app'
+        raise RuntimeError("Cannot reverse this migration. 'LogRecord.app' and its values cannot be restored.")
+        
+        # The following code is provided here to aid in writing a correct migration
+        # Changing field 'LogRecord.app'
+        db.alter_column(u'log4django_logrecord', 'app_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['log4django.App']))
+
+    models = {
+        u'log4django.app': {
+            'Meta': {'ordering': "('name',)", 'object_name': 'App'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'default': "'3302a266-0bb2-434c-8dd9-c73a5c524ad1'", 'unique': 'True', 'max_length': '36'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'log4django.logrecord': {
+            'Meta': {'ordering': "('-id',)", 'object_name': 'LogRecord'},
+            '_extra': ('django.db.models.fields.TextField', [], {'default': "'{}'"}),
+            'app': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'records'", 'null': 'True', 'to': u"orm['log4django.App']"}),
+            'exception_message': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'exception_traceback': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'fileName': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'level': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'lineNumber': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'loggerName': ('django.db.models.fields.CharField', [], {'max_length': '225'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'request_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '36', 'null': 'True', 'blank': 'True'}),
+            'thread': ('django.db.models.fields.CharField', [], {'max_length': '225', 'null': 'True', 'blank': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {})
+        }
+    }
+
+    complete_apps = ['log4django']

--- a/log4django/models.py
+++ b/log4django/models.py
@@ -21,7 +21,7 @@ class LogRecord(models.Model):
         (logging.CRITICAL, 'CRITICAL', _('CRITICAL'))
     )
 
-    app = models.ForeignKey('App', related_name='records')
+    app = models.ForeignKey('App', related_name='records', null=True)
     loggerName = models.CharField(max_length=225)
     level = models.PositiveSmallIntegerField(choices=LEVEL, default=LEVEL.NOTSET)
     timestamp = models.DateTimeField()


### PR DESCRIPTION
If `LogRecord.app` has null set to false, Django generates query like this:

```
SELECT 
`log4django_logrecord`.`id`, `log4django_logrecord`.`app_id`, `log4django_logrecord`.`loggerName`, 
`log4django_logrecord`.`level`, `log4django_logrecord`.`timestamp`, `log4django_logrecord`.`message`,
 `log4django_logrecord`.`fileName`, `log4django_logrecord`.`lineNumber`, `log4django_logrecord`.`thread`, 
`log4django_logrecord`.`exception_message`, `log4django_logrecord`.`exception_traceback`, `log4django_logrecord`.`request_id`,
`log4django_logrecord`.`_extra`, `log4django_app`.`id`, `log4django_app`.`key`, `log4django_app`.`name`, `log4django_app`.`description` 
FROM `log4django_logrecord`
INNER JOIN `log4django_app` ON ( `log4django_logrecord`.`app_id` = `log4django_app`.`id` )
ORDER BY `log4django_logrecord`.`id` DESC
LIMIT 100 OFFSET 2600;
```

which is really slow for bigger count of rows. If null is set to true, `INNER` is changed to `LEFT` join.
